### PR TITLE
홈 화면 스크롤 중첩 문제 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/tabs/common/HorizontalScrollListener.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/tabs/common/HorizontalScrollListener.kt
@@ -1,0 +1,23 @@
+package com.woowa.banchan.ui.tabs.common
+
+import android.view.MotionEvent
+import androidx.recyclerview.widget.RecyclerView
+
+class HorizontalScrollListener: RecyclerView.OnItemTouchListener {
+    override fun onInterceptTouchEvent(rv: RecyclerView, e: MotionEvent): Boolean {
+        if (rv.canScrollHorizontally(1) || rv.canScrollHorizontally(-1))
+            when (e.action) {
+                MotionEvent.ACTION_MOVE -> rv.parent
+                    .requestDisallowInterceptTouchEvent(true)
+                MotionEvent.ACTION_UP -> rv.parent
+                    .requestDisallowInterceptTouchEvent(false)
+            }
+        else
+            rv.parent
+                .requestDisallowInterceptTouchEvent(false)
+        return false
+    }
+
+    override fun onTouchEvent(rv: RecyclerView, e: MotionEvent) {}
+    override fun onRequestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {}
+}

--- a/app/src/main/java/com/woowa/banchan/ui/tabs/home/PlanAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/tabs/home/PlanAdapter.kt
@@ -7,6 +7,7 @@ import com.woowa.banchan.databinding.ItemBanchanHorizontalBinding
 import com.woowa.banchan.domain.entity.Category
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.ui.tabs.common.BanchanItemAdapter
+import com.woowa.banchan.ui.tabs.common.HorizontalScrollListener
 
 class PlanAdapter(
     private val planItems: List<Category>,
@@ -49,6 +50,7 @@ class PlanAdapter(
         fun bind(item: Category) {
             binding.category = item.title
             binding.rvHome.adapter = banchanItemAdapter
+            binding.rvHome.addOnItemTouchListener(HorizontalScrollListener())
             banchanItemAdapter.submitList(item.menus)
         }
     }


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 홈 화면에서 각 카테고리의 가로 스크롤 보다 탭 간의 스와이프가 우선순위가 되는 문제 해결
- `canScrollHorizontally`에 `1`을 주게 되면 오른쪽 스크롤이 가능한지 체크
- `canScrollHorizontally`에 `-1`을 주게 되면 왼쪽 스크롤이 가능한지 체크

## What has changed? 🤔

- 이슈 사항
  - #43 

- 변경 사항 
  - 왼쪽 or 오른쪽으로 스크롤링할 수 있는 상태면 RecyclerView에게 우선순위
  - 할 수 없는 상태면(스크롤될만큼 Item이 많지 않다던지) ViewPager에게 우선순위