### PR TITLE
화면 전환 시 프래그먼트 전환 객체를 보존하지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/main/MainFragment.kt
@@ -10,11 +10,10 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMainBinding
 import com.woowa.banchan.ui.detail.DetailFragment
 import com.woowa.banchan.ui.tabs.ViewPagerAdapter
-import com.woowa.banchan.ui.tabs.common.OnClickMenu
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainFragment : Fragment(), OnClickMenu {
+class MainFragment : Fragment() {
 
     private var _binding: FragmentMainBinding? = null
     private val binding: FragmentMainBinding get() = requireNotNull(_binding)
@@ -36,14 +35,14 @@ class MainFragment : Fragment(), OnClickMenu {
     private fun initView() {
         with(binding) {
             vpOrdering.adapter =
-                ViewPagerAdapter(childFragmentManager, lifecycle, this@MainFragment)
+                ViewPagerAdapter(childFragmentManager, lifecycle)
             TabLayoutMediator(tlOrdering, vpOrdering) { tab, position ->
                 tab.text = Tab.find(position)
             }.attach()
         }
     }
 
-    override fun navigateToDetail(hash: String, name: String, description: String) {
+    fun navigateToDetail(hash: String, name: String, description: String) {
         parentFragmentManager.beginTransaction()
             .addToBackStack(null)
             .replace(R.id.fcv_main, DetailFragment.newInstance(hash, name, description))

--- a/app/src/main/java/com/woowa/banchan/ui/tabs/ViewPagerAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/tabs/ViewPagerAdapter.kt
@@ -5,7 +5,6 @@ import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.woowa.banchan.ui.main.Tab
-import com.woowa.banchan.ui.tabs.common.OnClickMenu
 import com.woowa.banchan.ui.tabs.home.HomeFragment
 import com.woowa.banchan.ui.tabs.maindish.MainDishFragment
 import com.woowa.banchan.ui.tabs.side.SideFragment
@@ -13,27 +12,18 @@ import com.woowa.banchan.ui.tabs.soup.SoupFragment
 
 class ViewPagerAdapter(
     fm: FragmentManager,
-    lifecycle: Lifecycle,
-    private val onClickMenu: OnClickMenu
+    lifecycle: Lifecycle
 ) : FragmentStateAdapter(fm, lifecycle) {
 
     override fun getItemCount(): Int = SIZE
 
     override fun createFragment(position: Int): Fragment {
         return when (position) {
-            Tab.HOME.ordinal -> {
-                val homeFragment = HomeFragment()
-                homeFragment.setOnClickMenu(onClickMenu)
-                homeFragment
-            }
+            Tab.HOME.ordinal -> HomeFragment()
             Tab.MAIN_DISH.ordinal -> MainDishFragment()
             Tab.SOUP.ordinal -> SoupFragment()
             Tab.SIDE.ordinal -> SideFragment()
-            else -> {
-                val homeFragment = HomeFragment()
-                homeFragment.setOnClickMenu(onClickMenu)
-                homeFragment
-            }
+            else -> HomeFragment()
         }
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/tabs/common/OnClick.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/tabs/common/OnClick.kt
@@ -1,6 +1,0 @@
-package com.woowa.banchan.ui.tabs.common
-
-interface OnClickMenu {
-
-    fun navigateToDetail(hash: String, name: String, description: String)
-}

--- a/app/src/main/java/com/woowa/banchan/ui/tabs/home/HomeFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/tabs/home/HomeFragment.kt
@@ -12,9 +12,9 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.ConcatAdapter
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentHomeBinding
+import com.woowa.banchan.ui.main.MainFragment
 import com.woowa.banchan.ui.tabs.common.BannerAdapter
 import com.woowa.banchan.ui.tabs.common.CartBottomSheet
-import com.woowa.banchan.ui.tabs.common.OnClickMenu
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -26,7 +26,6 @@ class HomeFragment() : Fragment() {
     private val binding: FragmentHomeBinding get() = requireNotNull(_binding)
 
     private val concatAdapter = ConcatAdapter()
-    private lateinit var onClickMenu: OnClickMenu
     private lateinit var planAdapter: PlanAdapter
 
     private val planViewModel: PlanViewModel by viewModels()
@@ -58,7 +57,7 @@ class HomeFragment() : Fragment() {
                         planAdapter = PlanAdapter(
                             state.plans,
                             onClick = { product ->
-                                onClickMenu.navigateToDetail(product.detailHash, product.title, product.description)
+                                (parentFragment as MainFragment).navigateToDetail(product.detailHash, product.title, product.description)
                             },
                             onClickCart = { CartBottomSheet(it).show(childFragmentManager, "cart") }
                         )
@@ -77,10 +76,6 @@ class HomeFragment() : Fragment() {
                 true
             )
         )
-    }
-
-    fun setOnClickMenu(onClickMenu: OnClickMenu) {
-        this.onClickMenu = onClickMenu
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 화면 전환 시 프래그먼트 전환 객체를 보존하지 않는 문제 해결.
- onClickMenu 객체를 save instance를 하려고 시도해봤으나, Parcelable implements 시에 fragmentManager를 이용할 수 없는 문제가 있었음.
- 하위 Fragment의 인스턴스를 어딘가에 저장하려고 시도해봤으나, 마땅한 방법을 찾지 못함.
- parentFragmentManager에게서 Tag로 가져올 수 있었을지도 모르겠긴 함..
- 하지만 지금 결정한 방식이 가장 깔끔하다고 보았음.

## What has changed? 🤔

- 이슈 사항
  - #44 

- 변경 사항 
  - 단순히 `navigateToDetail(...)`을 `MainFragment`에 `public` 메소드로 선언하여
  `HomeFragment`에서 `parentFragment`의 멤버 함수를 호출