### PR TITLE
홈 화면이 재생성될 때마다 동일한 화면이 아래에 추가되는 문제 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/detail/DetailFragment.kt
@@ -51,8 +51,8 @@ class DetailFragment : Fragment() {
     }
 
     private fun observeData() {
-        lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 detailViewModel.state.collectLatest { state ->
                     initBinding(state.product)
                     initIndicators(state.product.thumbs)

--- a/app/src/main/java/com/woowa/banchan/ui/tabs/home/HomeFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/tabs/home/HomeFragment.kt
@@ -25,7 +25,7 @@ class HomeFragment() : Fragment() {
     private var _binding: FragmentHomeBinding? = null
     private val binding: FragmentHomeBinding get() = requireNotNull(_binding)
 
-    private val concatAdapter = ConcatAdapter()
+    private lateinit var concatAdapter: ConcatAdapter
     private lateinit var onClickMenu: OnClickMenu
     private lateinit var planAdapter: PlanAdapter
 
@@ -51,10 +51,17 @@ class HomeFragment() : Fragment() {
     }
 
     private fun observeData() {
-        lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 planViewModel.state.collectLatest { state ->
                     if (state.plans.isNotEmpty()) {
+                        concatAdapter.addAdapter(
+                            BannerAdapter(
+                                listOf(getString(R.string.plan_banner_title)),
+                                true
+                            )
+                        )
+
                         planAdapter = PlanAdapter(
                             state.plans,
                             onClick = { product ->
@@ -71,12 +78,7 @@ class HomeFragment() : Fragment() {
     }
 
     private fun setAdapter() {
-        concatAdapter.addAdapter(
-            BannerAdapter(
-                listOf(getString(R.string.plan_banner_title)),
-                true
-            )
-        )
+        concatAdapter = ConcatAdapter()
     }
 
     fun setOnClickMenu(onClickMenu: OnClickMenu) {


### PR DESCRIPTION
## Explain this Pull Request 🙏

- subscribe에서 `Fragment`의 `Lifecycle`을 이용하게 되면 `onDestroyView`에서 subscribe가 파괴되지 않고 `onCreateView` 마다 중첩해서 생기는 문제였다.
- `onDestroyView`에서 확실하게 파괴되는 `viewLifecycleOwner`를 쓰면 된다! 

## What has changed? 🤔

- 이슈 사항
  - #47 

- 변경 사항 
  - flow 감지 `lifecycle` 범위를 `viewLifecycle`로 변경하여 `collect`가 중복 호출되지 않도록 함
  - `concatAdapter`를 `onViewCreated` 될 때마다 초기화

## Screenshot 📸
![image](https://user-images.githubusercontent.com/47631768/184528647-81de78e2-2edf-4b90-b642-7d818e4ac1d8.png)
<img src="https://user-images.githubusercontent.com/47631768/184528657-044e6479-4277-4ecb-a106-d862e25c9f69.png" width="600"/>
