### PR TITLE
최근 본 상품 flow에게 강제로 발행을 요청하지 않아도 흐름에 따라 발행되도록 함

### DIFF
--- a/app/src/androidTest/java/com/woowa/banchan/data/local/FakeRecentlyViewedDataSource.kt
+++ b/app/src/androidTest/java/com/woowa/banchan/data/local/FakeRecentlyViewedDataSource.kt
@@ -13,14 +13,6 @@ class FakeRecentlyViewedDataSource(
         return flow { emit(recentlyViewedList) }
     }
 
-    override fun getTop7RecentlyViewed(): Flow<List<RecentlyViewedEntity>> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun addRecentlyViewed(recentlyViewed: RecentlyViewedEntity): Long {
-        TODO("Not yet implemented")
-    }
-
     override suspend fun modifyRecentlyViewed(recentlyViewed: RecentlyViewedEntity) {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/RecentlyViewedRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/RecentlyViewedRepositoryImpl.kt
@@ -7,10 +7,7 @@ import com.woowa.banchan.domain.entity.RecentlyViewed
 import com.woowa.banchan.domain.exception.NotFoundProductsException
 import com.woowa.banchan.domain.repository.RecentlyViewedRepository
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -19,8 +16,12 @@ class RecentlyViewedRepositoryImpl @Inject constructor(
 ): RecentlyViewedRepository {
 
     override suspend fun getAllRecentlyViewed(): Flow<Result<List<RecentlyViewed>>> = flow {
-        val list = recentlyViewedDataSource.getAllRecentlyViewed().first()
-        emit(Result.success(list.map { it.toRecentlyViewed() }))
+        recentlyViewedDataSource.getAllRecentlyViewed()
+            .collect { list ->
+                emit(Result.success(list.map { it.toRecentlyViewed() }))
+            }
+    }.catch {
+        emit(Result.failure(NotFoundProductsException()))
     }
 
     override suspend fun modifyRecentlyViewed(recentlyViewed: RecentlyViewed) {

--- a/app/src/main/java/com/woowa/banchan/ui/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/CartFragment.kt
@@ -15,6 +15,7 @@ import com.woowa.banchan.ui.OnRecentlyClickListener
 import com.woowa.banchan.ui.detail.DetailFragment
 import com.woowa.banchan.ui.recently.RecentlyFragment
 import com.woowa.banchan.ui.recently.RecentlyViewModel
+import java.util.*
 
 class CartFragment: Fragment(), OnRecentlyClickListener, OnDetailClickListener {
 
@@ -40,7 +41,10 @@ class CartFragment: Fragment(), OnRecentlyClickListener, OnDetailClickListener {
                 cartViewModel,
                 recentlyViewModel,
                 navigateToRecently = { navigateToRecently() },
-                onItemClick = { navigateToDetail(it.hash, it.name, it.description) }
+                onItemClick = {
+                    navigateToDetail(it.hash, it.name, it.description)
+                    recentlyViewModel.modifyRecently(it.copy(viewedAt = Calendar.getInstance().time.time))
+                }
             )
         }
 

--- a/app/src/main/java/com/woowa/banchan/ui/recently/RecentlyViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/recently/RecentlyViewModel.kt
@@ -66,11 +66,9 @@ class RecentlyViewModel @Inject constructor(
             hash, name, description, imageUrl, nPrice, sPrice, viewedAt
         )
         modifyRecentlyViewedUseCase(newRecently)
-        getRecently()
     }
 
     fun modifyRecently(recentlyViewed: RecentlyViewed) = viewModelScope.launch {
         modifyRecentlyViewedUseCase(recentlyViewed)
-        getRecently()
     }
 }


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 기존에 first()를 이용해 단일 발행값만을 보장하는 코드를 작성했기 때문에 Flow 발행값이 정기적으로 collect 되지 않았다고 추측.
- collect를 이용해 발행값을 항상 흘려보내도록 함.
- catch를 최상단 flow builder에 정의하여 내부 흐름에서 던져진 Throwable 또한 catching할 수 있도록 구현

## What has changed? 🤔

- 변경 사항 
  - 그 외는 CartFragment에서도 방문이 가능하니, RecentlyViewed도 갱신될 수 있도록 함