### PR TITLE
탭 상품 조회 유스케이스 개선

### DIFF
--- a/app/src/main/java/com/woowa/banchan/domain/entity/Product.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/entity/Product.kt
@@ -11,6 +11,7 @@ data class Product(
     val sPrice: String,
     val badge: List<String>?,
     val viewedAt: String = "",
+    var hasCart: Boolean = false
 ) {
     val discountRate: String
         get() = if (nPrice == null) ""

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/GetPlanUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/GetPlanUseCase.kt
@@ -1,14 +1,35 @@
 package com.woowa.banchan.domain.usecase
 
 import com.woowa.banchan.domain.entity.Category
+import com.woowa.banchan.domain.exception.NotFoundProductsException
 import com.woowa.banchan.domain.repository.BanchanRepository
-import kotlinx.coroutines.flow.Flow
+import com.woowa.banchan.domain.usecase.cart.GetCartUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 class GetPlanUseCase @Inject constructor(
-    private val repository: BanchanRepository
+    private val repository: BanchanRepository,
+    private val getCartUseCase: GetCartUseCase
 ) {
-    operator fun invoke(): Flow<Result<List<Category>>> {
-        return repository.getPlan()
-    }
+    operator fun invoke(): Flow<Result<List<Category>>> = flow {
+        getCartUseCase().combine(repository.getPlan()) { cart, plan ->
+            val categoryList = plan.getOrThrow()
+            val cartMap = cart.getOrThrow()
+            categoryList.map { category ->
+                val productList = category.menus.map { product ->
+                    if (cartMap.contains(product.detailHash)) {
+                        product.copy(hasCart = true)
+                    } else {
+                        product.copy(hasCart = false)
+                    }
+                }
+                category.copy(menus = productList)
+            }
+        }.collect {
+            emit(Result.success(it))
+        }
+    }.catch {
+        emit(Result.failure(NotFoundProductsException()))
+    }.flowOn(Dispatchers.IO)
 }

--- a/app/src/main/java/com/woowa/banchan/domain/usecase/GetProductsUseCase.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/usecase/GetProductsUseCase.kt
@@ -2,39 +2,49 @@ package com.woowa.banchan.domain.usecase
 
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.SortType
+import com.woowa.banchan.domain.exception.NotFoundProductsException
 import com.woowa.banchan.domain.repository.BanchanRepository
+import com.woowa.banchan.domain.usecase.cart.GetCartUseCase
 import com.woowa.banchan.extensions.toMoneyInt
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 class GetProductsUseCase @Inject constructor(
-    private val repository: BanchanRepository
+    private val repository: BanchanRepository,
+    private val getCartUseCase: GetCartUseCase
 ) {
-    operator fun invoke(type: String, sortType: SortType): Flow<Result<List<Product>>> = flow {
-        repository.getProducts(type)
-            .onEach { result ->
-                result
-                    .onSuccess { products ->
-                        when (sortType) {
-                            SortType.Default -> {
-                                emit(Result.success(products))
-                            }
-                            SortType.PriceAscending -> {
-                                emit(Result.success(products.sortedByDescending { it.sPrice.toMoneyInt() }))
-                            }
-                            SortType.PriceDescending -> {
-                                emit(Result.success(products.sortedBy { it.sPrice.toMoneyInt() }))
-                            }
-                            SortType.RateDescending -> {
-                                emit(Result.success(products.sortedByDescending { it.discountRate }))
-                            }
-                        }
-                    }
-                    .onFailure { emit(Result.failure(it)) }
+    operator fun invoke(
+        type: String,
+        sortType: SortType = SortType.Default
+    ): Flow<Result<List<Product>>> = flow {
+        getCartUseCase().combine(repository.getProducts(type)) { carts, products ->
+            val productList = products.getOrThrow()
+            val cartMap = carts.getOrThrow()
+            productList.map { product ->
+                if (cartMap.contains(product.detailHash)) {
+                    product.copy(hasCart = true)
+                } else {
+                    product.copy(hasCart = false)
+                }
             }
-            .collect()
-    }
+        }.collect { updateProducts ->
+            when (sortType) {
+                SortType.Default -> {
+                    emit(Result.success(updateProducts))
+                }
+                SortType.PriceAscending -> {
+                    emit(Result.success(updateProducts.sortedByDescending { it.sPrice.toMoneyInt() }))
+                }
+                SortType.PriceDescending -> {
+                    emit(Result.success(updateProducts.sortedBy { it.sPrice.toMoneyInt() }))
+                }
+                SortType.RateDescending -> {
+                    emit(Result.success(updateProducts.sortedByDescending { it.discountRate }))
+                }
+            }
+        }
+    }.catch {
+        emit(Result.failure(NotFoundProductsException()))
+    }.flowOn(Dispatchers.IO)
 }

--- a/app/src/main/java/com/woowa/banchan/ui/main/tabs/home/PlanAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/main/tabs/home/PlanAdapter.kt
@@ -9,10 +9,11 @@ import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.ui.main.tabs.adapter.ProductAdapter
 
 class PlanAdapter(
-    private val planItems: List<Category>,
     private val onClick: (Product) -> Unit,
     private val onClickCart: (Product) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+
+    private var planItems = mutableListOf<Category>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val inflater = LayoutInflater.from(parent.context)
@@ -30,6 +31,11 @@ class PlanAdapter(
                 holder.bind(planItems[position])
             }
         }
+    }
+
+    fun submitListCategory(categories: List<Category>) {
+        planItems = categories.toMutableList()
+        notifyDataSetChanged()
     }
 
     override fun getItemCount(): Int = planItems.size

--- a/app/src/main/java/com/woowa/banchan/ui/main/tabs/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/main/tabs/maindish/MainDishFragment.kt
@@ -24,6 +24,7 @@ import com.woowa.banchan.ui.main.tabs.decoration.ItemDecoration
 import com.woowa.banchan.ui.recently.RecentlyViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import java.util.*
 
 @AndroidEntryPoint
@@ -96,26 +97,28 @@ class MainDishFragment : Fragment() {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.state.collectLatest { state ->
-                if (state.products.isNotEmpty()) {
-                    productAdapter.submitList(state.products)
+            launch {
+                productsViewModel.state.collectLatest { state ->
+                    if (state.products.isNotEmpty()) {
+                        productAdapter.submitList(state.products)
+                    }
                 }
             }
-        }
 
-        viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.viewMode.collectLatest { viewMode ->
-                typeFilterAdapter.setViewMode(viewMode)
-                when (viewMode) {
-                    ProductViewType.Grid -> setGridLayoutManager()
-                    ProductViewType.Vertical -> setLinearLayoutManager()
+            launch {
+                productsViewModel.viewMode.collectLatest { viewMode ->
+                    typeFilterAdapter.setViewMode(viewMode)
+                    when (viewMode) {
+                        ProductViewType.Grid -> setGridLayoutManager()
+                        ProductViewType.Vertical -> setLinearLayoutManager()
+                    }
                 }
             }
-        }
 
-        viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.sortType.collectLatest { sortType ->
-                typeFilterAdapter.setSortType(sortType)
+            launch {
+                productsViewModel.sortType.collectLatest { sortType ->
+                    typeFilterAdapter.setSortType(sortType)
+                }
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/main/tabs/side/SideFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/main/tabs/side/SideFragment.kt
@@ -23,6 +23,7 @@ import com.woowa.banchan.ui.main.tabs.decoration.ItemDecoration
 import com.woowa.banchan.ui.recently.RecentlyViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import java.util.*
 
 @AndroidEntryPoint
@@ -95,17 +96,19 @@ class SideFragment : Fragment() {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.state.collectLatest { state ->
-                if (state.products.isNotEmpty()) {
-                    productAdapter.submitList(state.products)
-                    countFilterAdapter.submitTotalCount(state.products.size)
+            launch {
+                productsViewModel.state.collectLatest { state ->
+                    if (state.products.isNotEmpty()) {
+                        productAdapter.submitList(state.products)
+                        countFilterAdapter.submitTotalCount(state.products.size)
+                    }
                 }
             }
-        }
 
-        viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.sortType.collectLatest { sortType ->
-                countFilterAdapter.setSortType(sortType)
+            launch {
+                productsViewModel.sortType.collectLatest { sortType ->
+                    countFilterAdapter.setSortType(sortType)
+                }
             }
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/main/tabs/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/main/tabs/soup/SoupFragment.kt
@@ -23,6 +23,7 @@ import com.woowa.banchan.ui.main.tabs.decoration.ItemDecoration
 import com.woowa.banchan.ui.recently.RecentlyViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import java.util.*
 
 @AndroidEntryPoint
@@ -95,17 +96,19 @@ class SoupFragment : Fragment() {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.state.collectLatest { state ->
-                if (state.products.isNotEmpty()) {
-                    productAdapter.submitList(state.products)
-                    countFilterAdapter.submitTotalCount(state.products.size)
+            launch {
+                productsViewModel.state.collectLatest { state ->
+                    if (state.products.isNotEmpty()) {
+                        productAdapter.submitList(state.products)
+                        countFilterAdapter.submitTotalCount(state.products.size)
+                    }
                 }
             }
-        }
 
-        viewLifecycleOwner.repeatOnLifecycle {
-            productsViewModel.sortType.collectLatest { sortType ->
-                countFilterAdapter.setSortType(sortType)
+            launch {
+                productsViewModel.sortType.collectLatest { sortType ->
+                    countFilterAdapter.setSortType(sortType)
+                }
             }
         }
     }

--- a/app/src/main/res/drawable/ic_circle_in_cart.xml
+++ b/app/src/main/res/drawable/ic_circle_in_cart.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="32dp"
+    android:height="32dp"
+    android:viewportWidth="32"
+    android:viewportHeight="32">
+  <path
+      android:pathData="M16,0L16,0A16,16 0,0 1,32 16L32,16A16,16 0,0 1,16 32L16,32A16,16 0,0 1,0 16L0,16A16,16 0,0 1,16 0z"
+      android:fillColor="#F46700"/>
+  <path
+      android:pathData="M10.75,15.75L14.25,19.25L21.25,12.25"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/item_banchan_grid.xml
+++ b/app/src/main/res/layout/item_banchan_grid.xml
@@ -97,7 +97,7 @@
             android:layout_height="40dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="8dp"
-            android:background="@drawable/ic_circle_cart"
+            android:background="@{product.hasCart == true?@drawable/ic_circle_in_cart:@drawable/ic_circle_cart}"
             app:layout_constraintBottom_toBottomOf="@id/iv_banchan"
             app:layout_constraintEnd_toEndOf="@id/iv_banchan" />
 

--- a/app/src/main/res/layout/item_banchan_horizontal.xml
+++ b/app/src/main/res/layout/item_banchan_horizontal.xml
@@ -95,7 +95,7 @@
             android:layout_height="40dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="8dp"
-            android:background="@drawable/ic_circle_cart"
+            android:background="@{product.hasCart == true?@drawable/ic_circle_in_cart:@drawable/ic_circle_cart}"
             app:layout_constraintBottom_toBottomOf="@id/iv_banchan"
             app:layout_constraintEnd_toEndOf="@id/iv_banchan" />
 

--- a/app/src/main/res/layout/item_banchan_vertical.xml
+++ b/app/src/main/res/layout/item_banchan_vertical.xml
@@ -100,7 +100,7 @@
             android:layout_height="40dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="8dp"
-            android:background="@drawable/ic_circle_cart"
+            android:background="@{product.hasCart == true?@drawable/ic_circle_in_cart:@drawable/ic_circle_cart}"
             app:layout_constraintBottom_toBottomOf="@id/iv_banchan"
             app:layout_constraintEnd_toEndOf="@id/iv_banchan" />
 


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 기존 상품 API로만 가져온 데이터를 local 장바구니 테이블과 비교해서 처리해주기

## What has changed? 🤔

- 이슈 사항
  - #94 

- 변경 사항 
  - 내부에서 launch을 활용해 한 스코프로 처리할 수 있도록 설정
  - 상품 가져온 후, 카트에 존재하는지 판단하기 위해 hasCart 추가
  - 상품 hasCart 결과에 다른 카트 이미지 설정

  - 기존 emit처리만 해주던 것에서 장바구니 기능 추가
  - 장바구니에서 데이터와 API 호출로 데이터를 가져와서 flow combine 처리
  - 존재하는 경우, hasCart는 true / 그렇지 않으면 false

  - 기획전에 데이터반영을 쉽게 할 수 있도록 함수 생성
  - submitListCategory 메소드 생성
  - 리스트 데이터는 생성자로 받는 것이 아니라 포함하는 형태로 변경