### PR TITLE
주문 상세화면 UI 구현

### DIFF
--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderEntity.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderEntity.kt
@@ -3,7 +3,7 @@ package com.woowa.banchan.data.local.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import com.woowa.banchan.domain.entity.Order
+import com.woowa.banchan.domain.entity.OrderDetailSection.Order
 
 @Entity(tableName = "order")
 data class OrderEntity(

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderLineItemEntity.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderLineItemEntity.kt
@@ -4,7 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
-import com.woowa.banchan.domain.entity.OrderLineItem
+import com.woowa.banchan.domain.entity.OrderDetailSection.OrderLineItem
 
 @Entity(
     tableName = "order_line_item",

--- a/app/src/main/java/com/woowa/banchan/data/local/entity/OrderLineItemView.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/entity/OrderLineItemView.kt
@@ -2,8 +2,8 @@ package com.woowa.banchan.data.local.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.DatabaseView
-import com.woowa.banchan.domain.entity.Order
-import com.woowa.banchan.domain.entity.OrderLineItem
+import com.woowa.banchan.domain.entity.OrderDetailSection.Order
+import com.woowa.banchan.domain.entity.OrderDetailSection.OrderLineItem
 
 @DatabaseView(
     """

--- a/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
+++ b/app/src/main/java/com/woowa/banchan/data/local/repository/OrderRepositoryImpl.kt
@@ -2,8 +2,8 @@ package com.woowa.banchan.data.local.repository
 
 import com.woowa.banchan.data.local.datasource.OrderDataSource
 import com.woowa.banchan.data.local.entity.*
-import com.woowa.banchan.domain.entity.Order
-import com.woowa.banchan.domain.entity.OrderLineItem
+import com.woowa.banchan.domain.entity.OrderDetailSection.Order
+import com.woowa.banchan.domain.entity.OrderDetailSection.OrderLineItem
 import com.woowa.banchan.domain.exception.NotFoundProductsException
 import com.woowa.banchan.domain.repository.OrderRepository
 import kotlinx.coroutines.flow.Flow
@@ -13,7 +13,7 @@ import javax.inject.Inject
 
 class OrderRepositoryImpl @Inject constructor(
     private val orderDataSource: OrderDataSource
-): OrderRepository {
+) : OrderRepository {
 
     private val orderMap = mutableMapOf<Order, MutableList<OrderLineItem>>()
 
@@ -21,7 +21,7 @@ class OrderRepositoryImpl @Inject constructor(
         orderDataSource.getAllOrder()
             .collect { list ->
                 list.forEach {
-                    val keyOrder = it.toOrder()
+                    val keyOrder = it.toOrder().copy(count = list.size)
                     val orderLineItem = it.toOrderLineItem()
 
                     if (orderMap.containsKey(keyOrder))

--- a/app/src/main/java/com/woowa/banchan/domain/entity/Order.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/entity/Order.kt
@@ -1,7 +1,0 @@
-package com.woowa.banchan.domain.entity
-
-data class Order(
-    val id: Long = 0,
-    val orderedAt: Long,
-    val status: String
-)

--- a/app/src/main/java/com/woowa/banchan/domain/entity/OrderDetailSection.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/entity/OrderDetailSection.kt
@@ -1,0 +1,21 @@
+package com.woowa.banchan.domain.entity
+
+sealed class OrderDetailSection {
+    data class OrderLineItem(
+        val name: String,
+        val imageUrl: String,
+        val quantity: Int,
+        val price: String
+    ) : OrderDetailSection()
+
+    data class Order(
+        val id: Long = 0,
+        val orderedAt: Long,
+        val status: String,
+        val count: Int = 0
+    ) : OrderDetailSection()
+
+    data class OrderFooter(
+        val price: Int
+    ) : OrderDetailSection()
+}

--- a/app/src/main/java/com/woowa/banchan/domain/entity/OrderLineItem.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/entity/OrderLineItem.kt
@@ -1,8 +1,0 @@
-package com.woowa.banchan.domain.entity
-
-data class OrderLineItem(
-    val name: String,
-    val imageUrl: String,
-    val quantity: Int,
-    val price: String
-)

--- a/app/src/main/java/com/woowa/banchan/domain/repository/OrderRepository.kt
+++ b/app/src/main/java/com/woowa/banchan/domain/repository/OrderRepository.kt
@@ -1,7 +1,7 @@
 package com.woowa.banchan.domain.repository
 
-import com.woowa.banchan.domain.entity.Order
-import com.woowa.banchan.domain.entity.OrderLineItem
+import com.woowa.banchan.domain.entity.OrderDetailSection.Order
+import com.woowa.banchan.domain.entity.OrderDetailSection.OrderLineItem
 import kotlinx.coroutines.flow.Flow
 
 interface OrderRepository {

--- a/app/src/main/java/com/woowa/banchan/extensions/TimeStringConverter.kt
+++ b/app/src/main/java/com/woowa/banchan/extensions/TimeStringConverter.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.extensions
 
 import java.util.*
+import java.util.concurrent.TimeUnit
 
 fun Long.toTimeString(): String {
     val today = Calendar.getInstance()
@@ -10,16 +11,16 @@ fun Long.toTimeString(): String {
     val diffMin = (today.time.time - target.time.time) / 60 / 1000
     val diffHour = (today.time.time - target.time.time) / 60 / 60 / 1000
 
-    return if (diffSec < 60)
-        "방금"
-    else if (diffHour < 1)
-        "${diffMin}분 전"
-    else if (diffHour < 24)
-        "${diffHour}시간 전"
-    else if (diffHour < 24 * 30)
-        "${diffHour / 24}일 전"
-    else if (diffHour < 24 * 30 * 12)
-        "${diffHour / (24 * 30)}달 전"
-    else
-        "${diffHour / (24 * 30 * 12)}년 전"
+    return if (diffSec < 60) "방금"
+    else if (diffHour < 1) "${diffMin}분 전"
+    else if (diffHour < 24) "${diffHour}시간 전"
+    else if (diffHour < 24 * 30) "${diffHour / 24}일 전"
+    else if (diffHour < 24 * 30 * 12) "${diffHour / (24 * 30)}달 전"
+    else "${diffHour / (24 * 30 * 12)}년 전"
+}
+
+fun Long.getDiffTime(): Long {
+    val current = System.currentTimeMillis()
+    val diff = this - current
+    return TimeUnit.MILLISECONDS.toMinutes(diff)
 }

--- a/app/src/main/java/com/woowa/banchan/ui/OnOrderClickListener.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/OnOrderClickListener.kt
@@ -1,0 +1,6 @@
+package com.woowa.banchan.ui
+
+interface OnOrderClickListener {
+
+    fun navigateToOrderDetail()
+}

--- a/app/src/main/java/com/woowa/banchan/ui/bindingadapter/TextViewBindingAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/bindingadapter/TextViewBindingAdapter.kt
@@ -1,4 +1,4 @@
-package com.woowa.banchan.ui.common
+package com.woowa.banchan.ui.bindingadapter
 
 import android.graphics.Paint
 import android.widget.TextView

--- a/app/src/main/java/com/woowa/banchan/ui/cart/components/CartPriceColumn.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/cart/components/CartPriceColumn.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
@@ -22,7 +23,8 @@ fun CartPriceColumn(
     Column(
         modifier = modifier
             .padding(16.dp, 8.dp)
-            .width(IntrinsicSize.Max)
+            .width(IntrinsicSize.Max),
+        horizontalAlignment = Alignment.End
     ) {
         PriceRow(
             label = stringResource(R.string.cart_ordering_price),

--- a/app/src/main/java/com/woowa/banchan/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/main/MainFragment.kt
@@ -11,12 +11,14 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMainBinding
 import com.woowa.banchan.ui.OnCartClickListener
 import com.woowa.banchan.ui.OnDetailClickListener
+import com.woowa.banchan.ui.OnOrderClickListener
 import com.woowa.banchan.ui.cart.CartFragment
 import com.woowa.banchan.ui.detail.DetailFragment
+import com.woowa.banchan.ui.orderdetail.OrderDetailFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener {
+class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener, OnOrderClickListener {
 
     private var _binding: FragmentMainBinding? = null
     private val binding: FragmentMainBinding get() = requireNotNull(_binding)
@@ -48,6 +50,7 @@ class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener {
 
     private fun initListener() {
         binding.cartClickListener = this
+        binding.orderClickListener = this
         binding.active = true
         binding.cartCount = 10
     }
@@ -65,6 +68,15 @@ class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener {
         parentFragmentManager.beginTransaction()
             .addToBackStack("Main")
             .add(R.id.fcv_main, CartFragment())
+            .commit()
+    }
+
+
+    override fun navigateToOrderDetail() {
+        parentFragmentManager.popBackStack("Main", FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        parentFragmentManager.beginTransaction()
+            .addToBackStack("Main")
+            .add(R.id.fcv_main, OrderDetailFragment())
             .commit()
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/orderdetail/OrderDetailAdapter.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/orderdetail/OrderDetailAdapter.kt
@@ -1,0 +1,156 @@
+package com.woowa.banchan.ui.orderdetail
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.woowa.banchan.databinding.ItemOrderDetailBinding
+import com.woowa.banchan.databinding.ItemOrderDetailFooterBinding
+import com.woowa.banchan.databinding.ItemOrderDetailHeaderBinding
+import com.woowa.banchan.domain.entity.OrderDetailSection
+import com.woowa.banchan.domain.entity.OrderDetailSection.*
+import com.woowa.banchan.extensions.getDiffTime
+import com.woowa.banchan.extensions.toMoneyInt
+import com.woowa.banchan.extensions.toMoneyString
+import com.woowa.banchan.ui.cart.components.CartPriceColumn
+
+const val ORDER_HEADER = 0
+const val ORDER_CONTENT = 1
+const val ORDER_FOOTER = 2
+
+class OrderDetailAdapter(
+    private val onComplete: () -> Unit
+) : ListAdapter<OrderDetailSection, RecyclerView.ViewHolder>(orderDetailDiffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        val layoutInflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            ORDER_HEADER -> OrderDetailHeaderViewHolder(
+                ItemOrderDetailHeaderBinding.inflate(
+                    layoutInflater,
+                    parent,
+                    false
+                ),
+                onComplete
+            )
+            ORDER_CONTENT -> OrderDetailViewHolder(
+                ItemOrderDetailBinding.inflate(
+                    layoutInflater,
+                    parent,
+                    false
+                )
+            )
+            ORDER_FOOTER -> OrderDetailFooterViewHolder(
+                ItemOrderDetailFooterBinding.inflate(
+                    layoutInflater,
+                    parent,
+                    false
+                )
+            )
+            else -> throw Exception("unknown type")
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is OrderDetailHeaderViewHolder -> holder.bind(getItem(position) as Order)
+            is OrderDetailViewHolder -> holder.bind(getItem(position) as OrderLineItem)
+            is OrderDetailFooterViewHolder -> holder.bind(getItem(position) as OrderFooter)
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return when (currentList[position]) {
+            is Order -> ORDER_HEADER
+            is OrderLineItem -> ORDER_CONTENT
+            is OrderFooter -> ORDER_FOOTER
+        }
+    }
+
+    fun submitHeaderAndOrderList(orderList: Map<Order, List<OrderDetailSection>>) {
+        val orderItem = mutableListOf<OrderDetailSection>()
+        orderList.entries.forEach { entry ->
+            orderItem.add(entry.key)
+            orderItem.addAll(entry.value)
+            val value = entry.value
+            val totalSum = value.fold(0) { sum, orderLineItem ->
+                sum + if (orderLineItem is OrderLineItem) orderLineItem.quantity * orderLineItem.price.toMoneyInt() else 0
+            }
+            orderItem.add(OrderFooter(totalSum))
+        }
+        submitList(orderItem)
+    }
+
+
+    inner class OrderDetailHeaderViewHolder(
+        private val binding: ItemOrderDetailHeaderBinding,
+        private val onComplete: () -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(order: Order) {
+            binding.count = order.count
+            binding.deliveryState = order.status == "Start"
+
+            if (order.status == "Start") {
+                binding.tvDeliveryTimeTitle.isVisible = true
+                val minutes = (order.orderedAt + 1000 * 60 * 2).getDiffTime()
+                if (minutes > 0) binding.tvDeliveryTime.text = "${minutes}분"
+                else onComplete()
+            } else {
+                binding.tvDeliveryTimeTitle.isGone = true
+                binding.tvDeliveryTime.isGone = true
+            }
+        }
+    }
+
+    class OrderDetailViewHolder(private val binding: ItemOrderDetailBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(orderLineItem: OrderLineItem) {
+            binding.orderLineItem = orderLineItem
+            binding.totalPrice =
+                (orderLineItem.price.toMoneyInt() * orderLineItem.quantity).toMoneyString()
+        }
+    }
+
+    class OrderDetailFooterViewHolder(
+        private val binding: ItemOrderDetailFooterBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(orderFooter: OrderFooter) {
+            binding.composePrice.setContent {
+                CartPriceColumn(
+                    totalPrice = orderFooter.price,
+                    deliveryFee = 2500
+                )
+            }
+        }
+    }
+}
+
+
+val orderDetailDiffUtil = object : DiffUtil.ItemCallback<OrderDetailSection>() {
+    override fun areItemsTheSame(
+        oldItem: OrderDetailSection,
+        newItem: OrderDetailSection
+    ): Boolean {
+        if (oldItem is Order && newItem is Order) {
+            return oldItem.id == newItem.id
+        } else if (oldItem is OrderLineItem && newItem is OrderLineItem) {
+            return oldItem.name == newItem.name
+        } else if (oldItem is OrderFooter && newItem is OrderFooter) {
+            return oldItem.price == newItem.price
+        }
+        return false
+    }
+
+    override fun areContentsTheSame(
+        oldItem: OrderDetailSection,
+        newItem: OrderDetailSection
+    ): Boolean {
+        return oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/woowa/banchan/ui/orderdetail/OrderDetailFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/orderdetail/OrderDetailFragment.kt
@@ -1,0 +1,85 @@
+package com.woowa.banchan.ui.orderdetail
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.woowa.banchan.databinding.FragmentOrderDetailBinding
+import com.woowa.banchan.domain.entity.OrderDetailSection.Order
+import com.woowa.banchan.domain.entity.OrderDetailSection.OrderLineItem
+import com.woowa.banchan.ui.OnBackClickListener
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class OrderDetailFragment : Fragment() {
+
+    private var _binding: FragmentOrderDetailBinding? = null
+    private val binding: FragmentOrderDetailBinding get() = requireNotNull(_binding)
+    private val orderDetailAdapter by lazy {
+        OrderDetailAdapter(onComplete = this::onCompleteOrder)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentOrderDetailBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initView()
+        observeData()
+    }
+
+    private fun initView() {
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.listener = activity as OnBackClickListener
+    }
+
+    private fun observeData() {
+        binding.rvOrder.adapter = orderDetailAdapter
+        val orderLineItems = listOf<OrderLineItem>(
+            OrderLineItem(
+                name = "오징어 무침",
+                imageUrl = "",
+                quantity = 4,
+                price = "3,200원"
+            ),
+            OrderLineItem(
+                name = "오징어 무침",
+                imageUrl = "",
+                quantity = 3,
+                price = "7,200원"
+            ),
+            OrderLineItem(
+                name = "오징어 무침",
+                imageUrl = "",
+                quantity = 2,
+                price = "1,200원"
+            )
+        )
+        orderDetailAdapter.submitHeaderAndOrderList(
+            mapOf<Order, List<OrderLineItem>>(
+                Order(
+                    id = 1L,
+                    orderedAt = System.currentTimeMillis(),
+                    status = "Start",
+                    count = 3
+                ) to orderLineItems
+            )
+        )
+    }
+
+    private fun onCompleteOrder() {
+        // TODO 주문 완료시간 됬었을 때 처리
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -9,6 +9,10 @@
             type="com.woowa.banchan.ui.OnCartClickListener" />
 
         <variable
+            name="orderClickListener"
+            type="com.woowa.banchan.ui.OnOrderClickListener" />
+
+        <variable
             name="active"
             type="Boolean" />
 
@@ -33,7 +37,8 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:navigation_icon="@drawable/ic_logo"
-            app:onFirstClick="@{cartClickListener.navigateToCart}" />
+            app:onFirstClick="@{cartClickListener.navigateToCart}"
+            app:onSecondClick="@{orderClickListener.navigateToOrderDetail}" />
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tl_ordering"

--- a/app/src/main/res/layout/fragment_order_detail.xml
+++ b/app/src/main/res/layout/fragment_order_detail.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="listener"
+            type="com.woowa.banchan.ui.OnBackClickListener" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white">
+
+        <com.woowa.banchan.ui.customview.BanchanAppbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:navigation_icon="@drawable/ic_left_arrow"
+            app:onNavigationClick="@{listener::navigateToBack}" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_order"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:orientation="vertical"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            tools:listitem="@layout/item_order_detail" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/fragment_order_detail.xml
+++ b/app/src/main/res/layout/fragment_order_detail.xml
@@ -13,7 +13,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/white">
+        android:background="@color/grey_surface">
 
         <com.woowa.banchan.ui.customview.BanchanAppbar
             android:id="@+id/toolbar"

--- a/app/src/main/res/layout/item_order_detail.xml
+++ b/app/src/main/res/layout/item_order_detail.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="orderLineItem"
+            type="com.woowa.banchan.domain.entity.OrderDetailSection.OrderLineItem" />
+
+        <variable
+            name="totalPrice"
+            type="String" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="16dp">
+
+        <ImageView
+            android:id="@+id/order_detail_iv_food"
+            android:layout_width="80dp"
+            android:layout_height="0dp"
+            android:layout_marginStart="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:src="@{orderLineItem.imageUrl}" />
+
+        <TextView
+            android:id="@+id/order_detail_tv_title"
+            android:layout_width="0dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="8dp"
+            android:ellipsize="end"
+            android:gravity="center_vertical|left"
+            android:maxLines="1"
+            android:text="@{orderLineItem.name}"
+            app:layout_constraintBottom_toTopOf="@id/order_detail_tv_amount"
+            app:layout_constraintStart_toEndOf="@id/order_detail_iv_food"
+            app:layout_constraintTop_toTopOf="@id/order_detail_iv_food"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="새콤달콤 오징어무침" />
+
+        <TextView
+            android:id="@+id/order_detail_tv_amount"
+            android:layout_width="wrap_content"
+            android:layout_height="24dp"
+            android:layout_marginStart="8dp"
+            android:gravity="center_vertical"
+            android:text="@{@string/product_format(orderLineItem.quantity)}"
+            app:layout_constraintBottom_toTopOf="@id/order_detail_tv_sprice"
+            app:layout_constraintStart_toEndOf="@id/order_detail_iv_food"
+            app:layout_constraintTop_toBottomOf="@id/order_detail_tv_title"
+            tools:text="1개" />
+
+        <TextView
+            android:id="@+id/order_detail_tv_sprice"
+            android:layout_width="wrap_content"
+            android:layout_height="24dp"
+            android:layout_marginStart="8dp"
+            android:gravity="center_vertical"
+            android:text="@{totalPrice}"
+            app:layout_constraintBottom_toBottomOf="@id/order_detail_iv_food"
+            app:layout_constraintStart_toEndOf="@id/order_detail_iv_food"
+            app:layout_constraintTop_toBottomOf="@id/order_detail_tv_amount"
+            tools:text="21,140원" />
+
+        <View
+            android:id="@+id/order_detail_view_bottom"
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            android:visibility="gone"
+            app:layout_constraintTop_toBottomOf="@id/order_detail_iv_food" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_order_detail.xml
+++ b/app/src/main/res/layout/item_order_detail.xml
@@ -17,7 +17,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingVertical="16dp">
+        android:background="@color/white"
+        android:paddingVertical="8dp">
 
         <ImageView
             android:id="@+id/order_detail_iv_food"
@@ -28,7 +29,8 @@
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:src="@{orderLineItem.imageUrl}" />
+            app:src="@{orderLineItem.imageUrl}"
+            tools:src="@drawable/ic_launcher_background" />
 
         <TextView
             android:id="@+id/order_detail_tv_title"

--- a/app/src/main/res/layout/item_order_detail_footer.xml
+++ b/app/src/main/res/layout/item_order_detail_footer.xml
@@ -12,13 +12,22 @@
         android:background="@color/grey_surface">
 
         <View
+            android:id="@+id/view_space"
+            android:layout_width="match_parent"
+            android:layout_height="8dp"
+            android:background="@color/white"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <View
             android:id="@+id/view_divider"
             android:layout_width="0dp"
             android:layout_height="1dp"
             android:background="@color/gray_line"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/view_space" />
 
         <androidx.compose.ui.platform.ComposeView
             android:id="@+id/compose_price"
@@ -26,9 +35,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/view_divider"
-            app:layout_constraintVertical_bias="1.0" />
+            app:layout_constraintTop_toBottomOf="@id/view_divider" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_order_detail_footer.xml
+++ b/app/src/main/res/layout/item_order_detail_footer.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/grey_surface">
+
+        <View
+            android:id="@+id/view_divider"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="@color/gray_line"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_price"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_divider"
+            app:layout_constraintVertical_bias="1.0" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_order_detail_header.xml
+++ b/app/src/main/res/layout/item_order_detail_header.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="count"
+            type="Integer" />
+
+        <variable
+            name="deliveryState"
+            type="Boolean" />
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/grey_surface"
+        android:paddingHorizontal="16dp">
+
+        <TextView
+            android:id="@+id/tv_title"
+            style="@style/Theme.Banchan.Subtitle2.ItemPrimary"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingVertical="8dp"
+            android:text="@{deliveryState ? @string/product_order_start:@string/product_order_done}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="주문이 시작되었습니다." />
+
+        <TextView
+            android:id="@+id/tv_delivery_time_title"
+            style="@style/Theme.Banchan.Subtitle2.ItemPrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingVertical="8dp"
+            android:text="배송까지 남은 시간 "
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_title" />
+
+        <TextView
+            android:id="@+id/tv_delivery_time"
+            style="@style/Theme.Banchan.Subtitle2.ItemRate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            app:layout_constraintBottom_toBottomOf="@id/tv_delivery_time_title"
+            app:layout_constraintStart_toEndOf="@id/tv_delivery_time_title"
+            app:layout_constraintTop_toTopOf="@id/tv_delivery_time_title"
+            tools:text="20분" />
+
+        <TextView
+            android:id="@+id/tv_delivery_count_title"
+            style="@style/Theme.Banchan.Subtitle2.ItemPrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingVertical="8dp"
+            android:text="주문한 상품 "
+            app:layout_constraintStart_toStartOf="@id/tv_delivery_time_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_delivery_time_title" />
+
+        <TextView
+            android:id="@+id/tv_delivery_count"
+            style="@style/Theme.Banchan.Subtitle2.ItemPrimary"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:paddingVertical="8dp"
+            android:text="@{@string/product_format(count)}"
+            app:layout_constraintBottom_toBottomOf="@id/tv_delivery_count_title"
+            app:layout_constraintStart_toEndOf="@id/tv_delivery_count_title"
+            app:layout_constraintTop_toTopOf="@id/tv_delivery_count_title"
+            tools:text="총 2개" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@color/gray_line"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/item_order_detail_header.xml
+++ b/app/src/main/res/layout/item_order_detail_header.xml
@@ -18,14 +18,14 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/grey_surface"
-        android:paddingHorizontal="16dp">
+        android:background="@color/grey_surface">
 
         <TextView
             android:id="@+id/tv_title"
             style="@style/Theme.Banchan.Subtitle2.ItemPrimary"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginHorizontal="16dp"
             android:paddingVertical="8dp"
             android:text="@{deliveryState ? @string/product_order_start:@string/product_order_done}"
             app:layout_constraintStart_toStartOf="parent"
@@ -77,11 +77,21 @@
             tools:text="총 2개" />
 
         <View
+            android:id="@+id/view_divider"
             android:layout_width="match_parent"
             android:layout_height="1dp"
             android:background="@color/gray_line"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_delivery_count" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="8dp"
+            android:background="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/view_divider" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
 
     <string name="product_total_count">총 %d개 상품</string>
     <string name="product_format">%d개</string>
+    <string name="product_order_start">주문이 접수되었습니다.</string>
+    <string name="product_order_done">배송이 완료되었습니다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -47,4 +47,5 @@
     </string-array>
 
     <string name="product_total_count">총 %d개 상품</string>
+    <string name="product_format">%d개</string>
 </resources>


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 주문 상세화면 및 어댑터 생성

## What has changed? 🤔

- 이슈 사항
  - #98 

- 변경 사항 
  - 주문 상세화면에서 사용되기 위해 sealed class로 (Order, OrderLineItem, OrderFooter)을 묶어서 관리
  - 현재는 홈에서 프로필 누르면 주문 상세 화면으로 이동되게 구현해놓음 -> 추후 주문 화면 만들어지면 주문 화면으로 변경되게 설정!
  - Room에서 관리되는 주문시간을 + 1분 처리해서 주문이 완료되었는지 판단하는 확장함수 생성