### PR TITLE
앱 죽은 상태에서의 알림 클릭 시 화면 전환

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
@@ -61,7 +61,7 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
     private fun checkState(intent: Intent?) {
         this.intent = intent
         val orderId = intent?.getLongExtra(getString(R.string.order_id), 0) ?: 0
-        if(orderId == 0L) return
+        if (orderId == 0L) return
         supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
         supportFragmentManager.beginTransaction()
             .setCustomAnimations(

--- a/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
@@ -17,7 +17,6 @@ import com.woowa.banchan.ui.customview.LoadingFragment
 import com.woowa.banchan.ui.navigator.OnBackClickListener
 import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.network.NetworkConnectivityObserver
-import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
 import com.woowa.banchan.ui.screen.main.tabs.plan.PlanViewModel
 import com.woowa.banchan.ui.screen.orderdetail.OrderDetailFragment
@@ -51,17 +50,19 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
                 }
             }
         }
+        checkState(intent)
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
+        checkState(intent)
+    }
+
+    private fun checkState(intent: Intent?) {
         this.intent = intent
         val orderId = intent?.getLongExtra(getString(R.string.order_id), 0) ?: 0
+        if(orderId == 0L) return
         supportFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
-        supportFragmentManager.beginTransaction()
-            .replace(R.id.fcv_main, MainFragment())
-            .commit()
-
         supportFragmentManager.beginTransaction()
             .setCustomAnimations(
                 R.anim.slide_in,
@@ -79,7 +80,6 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
     }
 
     private fun checkNetwork(isActiveNetwork: Boolean) {
-        // FragmentTransactions are committed asynchronously
         supportFragmentManager.executePendingTransactions()
 
         if (isActiveNetwork) {


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 주문 하고나서, 앱 나가고나서 알림 클릭 시 상세 주문화면으로 이동

## What has changed? 🤔

- 이슈 사항
  - #145 

- 변경 사항 
  - 앱 죽은 상태에서 알림 클릭 시, onNewIntent로 이동하지 않고 onCreate로 다시 그려져서 판단하는 함수 생성