### PR TITLE
장바구니 변경에 대해 상품 상세화면에 반영되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/screen/detail/DetailFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/detail/DetailFragment.kt
@@ -90,9 +90,7 @@ class DetailFragment : Fragment(), OnCartClickListener, OnOrderClickListener {
             launch {
                 cartViewModel.state.collect {
                     cartViewModel.state.collect { state ->
-                        if (state.cart.isNotEmpty()) {
-                            binding.cartCount = state.cart.size
-                        }
+                        binding.cartCount = state.cart.size
                     }
                 }
             }


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 장바구니 변경에 대해 상품 상세화면에 반영되지 않는 문제 해결

## What has changed? 🤔

- 이슈 사항
  - #164 

- 문제
  - 메인 -> 상세화면 -> 장바구니에 담기 -> 다이얼로그(장바구니이동) -> 장바구니 목록 삭제(텅 화면 확인) -> 백버튼(상세화면)
     : 장바구니 개수가 텅임에도 불구하고 상단앱바에 숫자가 표시됨

- 변경 사항 
  - 빈 공간 일때 아이콘을 없애줘야 하는데, isNotEmpty()로 인해 처리되지 않은 현상
    - isNotEmpty() 제거