### PR TITLE
주문할 시 장바구니 빈 화면이 보이는 현상 해결 & 네트워크 끊김 현상 개선

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
@@ -94,8 +94,6 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
         }
     }
 
-    fun getNetworkFlow() = connectivityObserver.observe()
-
     override fun navigateToBack() {
         onBackPressed()
     }

--- a/app/src/main/java/com/woowa/banchan/ui/screen/cart/CartFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/cart/CartFragment.kt
@@ -95,6 +95,7 @@ class CartFragment :
                             cartViewModel.state.value.cart.count { cart -> cart.checked },
                             it.order
                         )
+                        cartViewModel.deleteCheckedCarts()
                     }
                 }
             }
@@ -111,7 +112,7 @@ class CartFragment :
                 R.anim.slide_out
             )
             .addToBackStack("Cart")
-            .add(R.id.fcv_main, RecentlyFragment())
+            .replace(R.id.fcv_main, RecentlyFragment())
             .commit()
     }
 
@@ -125,21 +126,16 @@ class CartFragment :
                 R.anim.slide_out
             )
             .addToBackStack("Cart")
-            .add(R.id.fcv_main, DetailFragment.newInstance(hash, name, description))
+            .replace(R.id.fcv_main, DetailFragment.newInstance(hash, name, description))
             .commit()
     }
 
     override fun navigateToOrderDetail(id: Long) {
         parentFragmentManager.popBackStack("Cart", FragmentManager.POP_BACK_STACK_INCLUSIVE)
         parentFragmentManager.beginTransaction()
-            .setCustomAnimations(
-                R.anim.slide_in,
-                R.anim.slide_out,
-                R.anim.slide_in,
-                R.anim.slide_out
-            )
             .addToBackStack("Cart")
             .add(R.id.fcv_main, OrderDetailFragment.newInstance(id))
+            .detach(this@CartFragment)
             .commit()
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/screen/cart/CartViewModel.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/cart/CartViewModel.kt
@@ -142,7 +142,6 @@ class CartViewModel @Inject constructor(
             val orderedAt = System.currentTimeMillis()
             val orderProducts = state.value.cart.filter { it.checked }
             val orderId = addOrderUserCase(orderProducts, orderedAt)
-            deleteCheckedCarts()
             _eventFlow.emit(UiEvent.OrderProduct(Order(orderId, orderedAt, DeliveryStatus.START)))
         }
     }

--- a/app/src/main/java/com/woowa/banchan/ui/screen/detail/DetailFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/detail/DetailFragment.kt
@@ -88,10 +88,8 @@ class DetailFragment : Fragment(), OnCartClickListener, OnOrderClickListener {
             }
 
             launch {
-                cartViewModel.state.collect {
-                    cartViewModel.state.collect { state ->
-                        binding.cartCount = state.cart.size
-                    }
+                cartViewModel.state.collect { state ->
+                    binding.cartCount = state.cart.size
                 }
             }
 

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/MainFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/MainFragment.kt
@@ -89,7 +89,7 @@ class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener, OnO
                 R.anim.slide_out
             )
             .addToBackStack("Main")
-            .add(R.id.fcv_main, DetailFragment.newInstance(hash, name, description))
+            .replace(R.id.fcv_main, DetailFragment.newInstance(hash, name, description))
             .commit()
     }
 
@@ -103,7 +103,7 @@ class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener, OnO
                 R.anim.slide_out
             )
             .addToBackStack("Main")
-            .add(R.id.fcv_main, CartFragment())
+            .replace(R.id.fcv_main, CartFragment())
             .commit()
     }
 
@@ -117,7 +117,7 @@ class MainFragment : Fragment(), OnDetailClickListener, OnCartClickListener, OnO
                 R.anim.slide_out
             )
             .addToBackStack("Main")
-            .add(R.id.fcv_main, OrderFragment())
+            .replace(R.id.fcv_main, OrderFragment())
             .commit()
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/maindish/MainDishFragment.kt
@@ -14,12 +14,10 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMaindishBinding
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.ProductViewType
-import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
-import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
@@ -89,14 +87,6 @@ class MainDishFragment : Fragment(), OnDetailClickListener {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            launch {
-                (requireActivity() as MainActivity).getNetworkFlow().collect {
-                    if (it == ConnectivityObserver.Status.Available) {
-                        productsViewModel.getProduct(getString(R.string.main_dish_tag))
-                    }
-                }
-            }
-
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbMainDish.visibility = state.isLoading.toVisibility()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/plan/PlanFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/plan/PlanFragment.kt
@@ -13,12 +13,10 @@ import androidx.recyclerview.widget.ConcatAdapter
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentPlanBinding
 import com.woowa.banchan.domain.entity.Product
-import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
-import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.adapter.BannerAdapter
@@ -69,14 +67,6 @@ class PlanFragment : Fragment(), OnDetailClickListener {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            launch {
-                (requireActivity() as MainActivity).getNetworkFlow().collect {
-                    if (it == ConnectivityObserver.Status.Available) {
-                        planViewModel.getPlan()
-                    }
-                }
-            }
-
             launch {
                 planViewModel.state.collectLatest { state ->
                     binding.pbPlan.visibility = state.isLoading.toVisibility()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/side/SideFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/side/SideFragment.kt
@@ -13,12 +13,10 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSideBinding
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.ProductViewType
-import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
-import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
@@ -87,14 +85,6 @@ class SideFragment : Fragment(), OnDetailClickListener {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            launch {
-                (requireActivity() as MainActivity).getNetworkFlow().collect {
-                    if (it == ConnectivityObserver.Status.Available) {
-                        productsViewModel.getProduct(getString(R.string.side_tag))
-                    }
-                }
-            }
-
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbSide.visibility = state.isLoading.toVisibility()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/soup/SoupFragment.kt
@@ -13,12 +13,10 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSoupBinding
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.ProductViewType
-import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
-import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
@@ -87,14 +85,6 @@ class SoupFragment : Fragment(), OnDetailClickListener {
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
-            launch {
-                (requireActivity() as MainActivity).getNetworkFlow().collect {
-                    if (it == ConnectivityObserver.Status.Available) {
-                        productsViewModel.getProduct(getString(R.string.soup_tag))
-                    }
-                }
-            }
-
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbSoup.visibility = state.isLoading.toVisibility()


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 주문할 시 장바구니 빈 화면(텅)이 보이는 현상 해결

## What has changed? 🤔

- 이슈 사항
  - #169 
  - #167

- 변경 사항 (주문할 시 장바구니 빈 화면)
  - flow 설정을 통해 변경사항이 바로 적용되는 현상 발생
    - 애니메이션 딜레이 시간 때문에 보이게 되므로 애니메이션 제거

- 변경 사항 (네트워크 끊김 현상 개선)
  - fragmentManager을 통해 처리
    - add에서 replace을 변경함으로써 네트워크 collect도 불필요해서 제거