### PR TITLE
네트워크 다이얼로그 + 화면 회전 이슈 해결

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
@@ -36,9 +36,18 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
         onNewIntent(intent)
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        initDialog()
+        observeNetwork()
+    }
+
     private fun initDialog() {
-        supportFragmentManager.findFragmentByTag(DIALOG_TAG)?.let {
-            dialog = it as LoadingFragment
+        supportFragmentManager.executePendingTransactions()
+
+        if (dialog.isAdded) {
+            dialog.dismiss()
+            dialog.show(supportFragmentManager, DIALOG_TAG)
         }
     }
 
@@ -76,11 +85,6 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
                 .add(R.id.fcv_main, OrderDetailFragment.newInstance(orderId))
                 .commit()
         }
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        observeNetwork()
     }
 
     private fun checkNetwork(isActiveNetwork: Boolean) {

--- a/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
@@ -48,6 +48,11 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
         if (dialog.isAdded) {
             dialog.dismiss()
             dialog.show(supportFragmentManager, DIALOG_TAG)
+            Toast.makeText(
+                applicationContext,
+                getString(R.string.message_network),
+                Toast.LENGTH_LONG
+            ).show()
         }
     }
 
@@ -95,12 +100,12 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
         } else {
             if (!dialog.isAdded) {
                 dialog.show(supportFragmentManager, DIALOG_TAG)
+                Toast.makeText(
+                    applicationContext,
+                    getString(R.string.message_network),
+                    Toast.LENGTH_LONG
+                ).show()
             }
-            Toast.makeText(
-                applicationContext,
-                getString(R.string.message_network),
-                Toast.LENGTH_LONG
-            ).show()
         }
     }
 

--- a/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.ui
 
 import android.content.Intent
+import android.content.res.Configuration
 import android.net.ConnectivityManager
 import android.os.Build
 import android.os.Bundle
@@ -77,6 +78,11 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
         }
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        observeNetwork()
+    }
+
     private fun checkNetwork(isActiveNetwork: Boolean) {
         supportFragmentManager.executePendingTransactions()
 
@@ -93,6 +99,8 @@ class MainActivity : AppCompatActivity(), OnBackClickListener {
             ).show()
         }
     }
+
+    fun getNetworkFlow() = connectivityObserver.observe()
 
     override fun navigateToBack() {
         onBackPressed()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/maindish/MainDishFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -99,7 +101,9 @@ class MainDishFragment : Fragment(), OnDetailClickListener {
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbMainDish.visibility = state.isLoading.toVisibility()
+                    binding.rvMainDish.isGone = true
                     if (state.products.isNotEmpty()) {
+                        binding.rvMainDish.isVisible = true
                         productAdapter.submitList(state.products)
                     }
                 }

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/maindish/MainDishFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/maindish/MainDishFragment.kt
@@ -14,10 +14,12 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentMaindishBinding
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.ProductViewType
+import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
+import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
@@ -81,12 +83,19 @@ class MainDishFragment : Fragment(), OnDetailClickListener {
 
     private fun initView() {
         binding.lifecycleOwner = viewLifecycleOwner
-        productsViewModel.getProduct(getString(R.string.main_dish_tag))
         binding.rvMainDish.adapter = concatAdapter
     }
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
+            launch {
+                (requireActivity() as MainActivity).getNetworkFlow().collect {
+                    if (it == ConnectivityObserver.Status.Available) {
+                        productsViewModel.getProduct(getString(R.string.main_dish_tag))
+                    }
+                }
+            }
+
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbMainDish.visibility = state.isLoading.toVisibility()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/plan/PlanFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/plan/PlanFragment.kt
@@ -13,10 +13,12 @@ import androidx.recyclerview.widget.ConcatAdapter
 import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentPlanBinding
 import com.woowa.banchan.domain.entity.Product
+import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
+import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.adapter.BannerAdapter
@@ -61,12 +63,19 @@ class PlanFragment : Fragment(), OnDetailClickListener {
     }
 
     private fun initView() {
-        planViewModel.getPlan()
         binding.rvPlan.adapter = concatAdapter
     }
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
+            launch {
+                (requireActivity() as MainActivity).getNetworkFlow().collect {
+                    if (it == ConnectivityObserver.Status.Available) {
+                        planViewModel.getPlan()
+                    }
+                }
+            }
+
             launch {
                 planViewModel.state.collectLatest { state ->
                     binding.pbPlan.visibility = state.isLoading.toVisibility()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/side/SideFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/side/SideFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -97,7 +99,9 @@ class SideFragment : Fragment(), OnDetailClickListener {
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbSide.visibility = state.isLoading.toVisibility()
+                    binding.rvSide.isGone = true
                     if (state.products.isNotEmpty()) {
+                        binding.rvSide.isVisible = true
                         productAdapter.submitList(state.products)
                         countFilterAdapter.submitTotalCount(state.products.size)
                     }

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/side/SideFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/side/SideFragment.kt
@@ -13,10 +13,12 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSideBinding
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.ProductViewType
+import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
+import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
@@ -78,13 +80,20 @@ class SideFragment : Fragment(), OnDetailClickListener {
 
     private fun initView() {
         binding.lifecycleOwner = viewLifecycleOwner
-        productsViewModel.getProduct(getString(R.string.side_tag))
         setGridLayoutManager()
         binding.rvSide.adapter = concatAdapter
     }
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
+            launch {
+                (requireActivity() as MainActivity).getNetworkFlow().collect {
+                    if (it == ConnectivityObserver.Status.Available) {
+                        productsViewModel.getProduct(getString(R.string.side_tag))
+                    }
+                }
+            }
+
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbSide.visibility = state.isLoading.toVisibility()

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/soup/SoupFragment.kt
@@ -5,6 +5,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.ConcatAdapter
@@ -97,7 +99,9 @@ class SoupFragment : Fragment(), OnDetailClickListener {
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbSoup.visibility = state.isLoading.toVisibility()
+                    binding.rvSoup.isGone = true
                     if (state.products.isNotEmpty()) {
+                        binding.rvSoup.isVisible = true
                         productAdapter.submitList(state.products)
                         countFilterAdapter.submitTotalCount(state.products.size)
                     }

--- a/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/soup/SoupFragment.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/screen/main/tabs/soup/SoupFragment.kt
@@ -13,10 +13,12 @@ import com.woowa.banchan.R
 import com.woowa.banchan.databinding.FragmentSoupBinding
 import com.woowa.banchan.domain.entity.Product
 import com.woowa.banchan.domain.entity.ProductViewType
+import com.woowa.banchan.ui.MainActivity
 import com.woowa.banchan.ui.customview.CartBottomSheet
 import com.woowa.banchan.ui.extensions.repeatOnLifecycle
 import com.woowa.banchan.ui.extensions.toVisibility
 import com.woowa.banchan.ui.navigator.OnDetailClickListener
+import com.woowa.banchan.ui.network.ConnectivityObserver
 import com.woowa.banchan.ui.screen.main.MainFragment
 import com.woowa.banchan.ui.screen.main.tabs.ProductUiEvent
 import com.woowa.banchan.ui.screen.main.tabs.ProductsViewModel
@@ -78,13 +80,20 @@ class SoupFragment : Fragment(), OnDetailClickListener {
 
     private fun initView() {
         binding.lifecycleOwner = viewLifecycleOwner
-        productsViewModel.getProduct(getString(R.string.soup_tag))
         setGridLayoutManager()
         binding.rvSoup.adapter = concatAdapter
     }
 
     private fun observeData() {
         viewLifecycleOwner.repeatOnLifecycle {
+            launch {
+                (requireActivity() as MainActivity).getNetworkFlow().collect {
+                    if (it == ConnectivityObserver.Status.Available) {
+                        productsViewModel.getProduct(getString(R.string.soup_tag))
+                    }
+                }
+            }
+
             launch {
                 productsViewModel.state.collectLatest { state ->
                     binding.pbSoup.visibility = state.isLoading.toVisibility()

--- a/app/src/main/res/layout/fragment_main.xml
+++ b/app/src/main/res/layout/fragment_main.xml
@@ -48,6 +48,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:tabGravity="center"
             app:tabBackground="@drawable/tab_underline"
             app:tabMinWidth="140dp"
             app:tabMode="scrollable"


### PR DESCRIPTION
## Explain this Pull Request 🙏

- ui : 네트워크 다이얼로그 레이아웃 버그 수정
- ui : 탭 레이아웃 정렬 버그 수정
- ui : 메인 프래그먼트 로딩 프로그래스바가 일부 가려지는 현상 수정
- ui : 토스트 메시지 중복 호출 방지
- 첫 진입 시, 화면 회전 시 발생 가능한 네트워크 변경 이슈 해결

## What has changed? 🤔

- 이슈 사항
  - #171 
  - #173 

- 변경 사항 
  - 누락된 `onConfigurationChanged` 다시 추가
  - `onConfigurationChanged`에도 dialog, Toast 관리 추가
  - 일부 UI 개선