### PR TITLE
화면 회전에 따른 알림창 크기 대응

### DIFF
--- a/app/src/main/java/com/woowa/banchan/ui/customview/CartDialog.kt
+++ b/app/src/main/java/com/woowa/banchan/ui/customview/CartDialog.kt
@@ -1,6 +1,7 @@
 package com.woowa.banchan.ui.customview
 
 import android.content.Context
+import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -25,6 +26,15 @@ class CartDialog : DialogFragment(), OnCartClickListener {
 
     override fun onResume() {
         super.onResume()
+        setDialogSize()
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        setDialogSize()
+    }
+
+    private fun setDialogSize() {
         val params: ViewGroup.LayoutParams? = dialog?.window?.attributes
         val windowManager =
             requireActivity().getSystemService(Context.WINDOW_SERVICE) as WindowManager


### PR DESCRIPTION
## Explain this Pull Request 🙏

- 화면이 회전되어도 알림창 크기가 고정되는 문제 해결

## What has changed? 🤔

- 변경 사항 
  - `CartDialog`에 `onConfigurationChanged` 정의